### PR TITLE
fix for building docker container directly from github url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 FROM node:18.12-alpine
 COPY app /opt/app/
 WORKDIR /opt/app/
+RUN npm install npm-run-all --save-dev
 RUN npm run build
 WORKDIR /opt/app/dist/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@
 #CMD ["/opt/app/index.js", "/var/lib/fritzbox-to-mqtt-gw/config.json"]
 
 FROM node:18.12-alpine
-COPY app/dist /opt/app/
+COPY app /opt/app/
 WORKDIR /opt/app/
+RUN npm run build
+WORKDIR /opt/app/dist/
 
 CMD ["node", "index.js", "/var/lib/fritzbox-to-mqtt-gw/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ WORKDIR /opt/app/
 RUN npm install npm-run-all --save-dev
 RUN npm run build
 WORKDIR /opt/app/dist/
+RUN mkdir /var/lib/fritzbox-to-mqtt-gw
 
 CMD ["node", "index.js", "/var/lib/fritzbox-to-mqtt-gw/config.json"]

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -28,7 +28,7 @@
                 "jest": "29.2.2",
                 "jest-junit": "14.0.1",
                 "jest-standard-reporter": "2.0.0",
-                "npm-run-all": "4.1.5",
+                "npm-run-all": "^4.1.5",
                 "rimraf": "3.0.2",
                 "testcontainers": "9.0.0",
                 "ts-jest": "29.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -32,7 +32,7 @@
         "jest": "29.2.2",
         "jest-junit": "14.0.1",
         "jest-standard-reporter": "2.0.0",
-        "npm-run-all": "4.1.5",
+        "npm-run-all": "^4.1.5",
         "rimraf": "3.0.2",
         "testcontainers": "9.0.0",
         "ts-jest": "29.0.3",


### PR DESCRIPTION
Ability to build and run it like:

docker build --tag pharndt/fritzboxmqtt:latest https://github.com/mqtt-home/fritzbox-to-mqtt-gw.git